### PR TITLE
Bannersnack fix.

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
 <script type="text/javascript">
 var bannersnack_embed = {"hash":"bz9szl0lc","width":970,"height":250,"t":1595753098,"userId":39265002,"type":"html5"};
 </script>
-<script type="text/javascript" src="//cdn.bannersnack.com/iframe/embed.js"></script>
+<script type="text/javascript" src="https://cdn.bannersnack.com/iframe/embed.js"></script>
     
   </body>
 </html>


### PR DESCRIPTION
Added "https:" to "cdn.banersnack.com/iframe/index.js".
Please merge this PR for Bannersnack compatibility on your website.